### PR TITLE
.pem 확장자 파일 찾기 버그

### DIFF
--- a/ec2gazua/ec2.py
+++ b/ec2gazua/ec2.py
@@ -140,8 +140,7 @@ class EC2Instance(object):
             return key_path
 
         if key_path.endswith('.pem'):
-            raw_path = isfile(key_path.rsplit('.pem', 1)[0])
-            return raw_path if isfile(raw_path) else None
+            return key_path if isfile(key_path) else None
 
         pem_path = key_path + '.pem'
         return pem_path if isfile(pem_path) else None


### PR DESCRIPTION
확장자가 pem 으로 끝나는경우에, split 하여 파일 이름을 추출 한뒤 isfile 호출시 오류가 발생합니다.

갓주현 👍  